### PR TITLE
Make class titles include clickable links to class details

### DIFF
--- a/entrypoints/content/app.tsx
+++ b/entrypoints/content/app.tsx
@@ -292,7 +292,15 @@ const App: FC = () => {
                     return (
                       <ClassCard key={classInfo.id}>
                         <div className="class-card-header">
-                          <h2>{classInfo.title}</h2>
+                          <h2>
+                            <a
+                              href={`https://app.leb2.org/class/${classInfo.id}/checkAfterAccessClass`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {classInfo.title}
+                            </a>
+                          </h2>
                           <p>{classInfo.description}</p>
                         </div>
                         <AssignmentContainer>

--- a/entrypoints/content/components/styled/Class.tsx
+++ b/entrypoints/content/components/styled/Class.tsx
@@ -31,6 +31,10 @@ export const ClassCard = styled.div`
       font-weight: 600;
       color: ${({ theme }) => theme.text};
       line-height: 1.2;
+
+      a:hover {
+        text-decoration: underline;
+      }
     }
 
     p {


### PR DESCRIPTION
This pull request adds a feature that makes class titles in the application include clickable links to the corresponding class details page. This allows users to easily navigate to the class details without having to manually search for the class.