### PR TITLE
feat: assignment filter

### DIFF
--- a/entrypoints/content/app.tsx
+++ b/entrypoints/content/app.tsx
@@ -22,11 +22,12 @@ import {
   ClassContainer,
 } from "@/entrypoints/content/components/styled/Class"
 import {
-  ButtonContainer,
   DropdownButton,
   DropdownContent,
   DropdownItem,
   DropdownLabel,
+  InlineContainer,
+  LinkText,
   TabButton,
   TabContainer,
 } from "@/entrypoints/content/components/styled/Dropdown"
@@ -65,12 +66,18 @@ const App: FC = () => {
   )
 
   const [filterAssignment, setFilterAssignment] = useState<TAssignmentFilter>({
-    isSubmit: false,
-    isNotSubmit: false,
-    isIND: false,
-    isGRP: false,
-    isAssignment: false,
-    isQuiz: false,
+    submit: {
+      isSubmit: false,
+      isNotSubmit: false,
+    },
+    type: {
+      isIND: false,
+      isGRP: false,
+    },
+    assessmentType: {
+      isAssignment: false,
+      isQuiz: false,
+    },
   })
 
   const allClassInfo = useMemo(() => getAllClassInfo(), [])
@@ -348,7 +355,7 @@ const App: FC = () => {
                     className="dropdown-container"
                     style={{ position: "relative" }}
                   >
-                    <ButtonContainer>
+                    <InlineContainer>
                       <DropdownButton
                         onClick={() => {
                           setIsDropdownOpen(!isDropdownOpen)
@@ -465,50 +472,112 @@ const App: FC = () => {
 
                       {isAssignmentFilterOpen && (
                         <DropdownContent>
-                          <DropdownLabel style={{ fontSize: "1rem" }}>
-                            Submit / Not Submit
+                          <DropdownLabel>
+                            <InlineContainer
+                              style={{ justifyContent: "space-between" }}
+                            >
+                              <p>Submit / Not Submit</p>
+                              <LinkText
+                                className="underline"
+                                onClick={() => {
+                                  setFilterAssignment({
+                                    ...filterAssignment,
+                                    submit: {
+                                      isNotSubmit: false,
+                                      isSubmit: false,
+                                    },
+                                  })
+                                }}
+                              >
+                                Clear
+                              </LinkText>
+                            </InlineContainer>
                           </DropdownLabel>
                           <AssignmentFilter
                             itemKey={"isSubmit"}
                             obj={filterAssignment}
                             setObj={setFilterAssignment}
                             inputLabel={"Submit"}
+                            section="submit"
                           />
                           <AssignmentFilter
                             itemKey={"isNotSubmit"}
                             obj={filterAssignment}
                             setObj={setFilterAssignment}
                             inputLabel={"Not Submit"}
+                            section="submit"
                           />
-                          <DropdownLabel>Individual / Group</DropdownLabel>
+                          <DropdownLabel>
+                            <InlineContainer
+                              style={{ justifyContent: "space-between" }}
+                            >
+                              <p>Individual / Group</p>
+                              <LinkText
+                                onClick={() => {
+                                  setFilterAssignment({
+                                    ...filterAssignment,
+                                    type: {
+                                      isGRP: false,
+                                      isIND: false,
+                                    },
+                                  })
+                                }}
+                              >
+                                Clear
+                              </LinkText>
+                            </InlineContainer>
+                          </DropdownLabel>
                           <AssignmentFilter
                             itemKey={"isIND"}
                             obj={filterAssignment}
                             setObj={setFilterAssignment}
                             inputLabel={"Individual"}
+                            section="type"
                           />
                           <AssignmentFilter
                             itemKey={"isGRP"}
                             obj={filterAssignment}
                             setObj={setFilterAssignment}
                             inputLabel={"Group"}
+                            section="type"
                           />
-                          <DropdownLabel>Assignment / Quiz</DropdownLabel>
+                          <DropdownLabel>
+                            <InlineContainer
+                              style={{ justifyContent: "space-between" }}
+                            >
+                              <p>Assignment / Quiz</p>
+                              <LinkText
+                                onClick={() => {
+                                  setFilterAssignment({
+                                    ...filterAssignment,
+                                    assessmentType: {
+                                      isQuiz: false,
+                                      isAssignment: false,
+                                    },
+                                  })
+                                }}
+                              >
+                                Clear
+                              </LinkText>
+                            </InlineContainer>
+                          </DropdownLabel>
                           <AssignmentFilter
                             itemKey={"isAssignment"}
                             obj={filterAssignment}
                             setObj={setFilterAssignment}
                             inputLabel={"Assignment"}
+                            section="assessmentType"
                           />
                           <AssignmentFilter
                             itemKey={"isQuiz"}
                             obj={filterAssignment}
                             setObj={setFilterAssignment}
                             inputLabel={"Quiz"}
+                            section="assessmentType"
                           />
                         </DropdownContent>
                       )}
-                    </ButtonContainer>
+                    </InlineContainer>
                   </div>
                   <h1>Assignments 🥰</h1>
                   <div className="settings-bar">
@@ -561,30 +630,30 @@ const App: FC = () => {
 
                     const filters = [
                       {
-                        condition: filterAssignment.isAssignment,
+                        condition: filterAssignment.assessmentType.isAssignment,
                         predicate: (task: TActivity) => task.type === "ASM",
                       },
                       {
-                        condition: filterAssignment.isQuiz,
+                        condition: filterAssignment.assessmentType.isQuiz,
                         predicate: (task: TActivity) => task.type === "QUZ",
                       },
                       {
-                        condition: filterAssignment.isGRP,
+                        condition: filterAssignment.type.isGRP,
                         predicate: (task: TActivity) =>
                           task.group_type === "STU",
                       },
                       {
-                        condition: filterAssignment.isIND,
+                        condition: filterAssignment.type.isIND,
                         predicate: (task: TActivity) =>
                           task.group_type === "IND",
                       },
                       {
-                        condition: filterAssignment.isNotSubmit,
+                        condition: filterAssignment.submit.isNotSubmit,
                         predicate: (task: TActivity) =>
                           !task.quiz_submission_is_submitted,
                       },
                       {
-                        condition: filterAssignment.isSubmit,
+                        condition: filterAssignment.submit.isSubmit,
                         predicate: (task: TActivity) =>
                           task.quiz_submission_is_submitted,
                       },

--- a/entrypoints/content/app.tsx
+++ b/entrypoints/content/app.tsx
@@ -89,17 +89,35 @@ const App: FC = () => {
         savedDarkMode,
         savedHiddenClasses,
         savedHiddenAssignments,
+        savedFilterSettings,
       ] = await Promise.all([
         storage.getItem<boolean>("local:assignmentsGridView"),
         storage.getItem<boolean>("local:darkMode"),
         storage.getItem<string[]>("local:hiddenClasses"),
         storage.getItem<string[]>("local:hiddenAssignments"),
+        storage.getItem<TAssignmentFilter>("local:filterSettings"),
       ])
 
       setIsGridView(savedView ?? false)
       setIsDarkMode(savedDarkMode ?? false)
       setHiddenClasses(savedHiddenClasses ?? [])
       setHiddenAssignments(savedHiddenAssignments ?? [])
+      setFilterAssignment(
+        savedFilterSettings ?? {
+          submit: {
+            isSubmit: false,
+            isNotSubmit: false,
+          },
+          type: {
+            isIND: false,
+            isGRP: false,
+          },
+          assessmentType: {
+            isAssignment: false,
+            isQuiz: false,
+          },
+        }
+      )
     }
     loadPreferences()
   }, [])
@@ -234,6 +252,14 @@ const App: FC = () => {
     }
     saveClassWithAssignments()
   }, [classWithAssignments])
+
+  useEffect(() => {
+    const saveFilterSettings = async () => {
+      await storage.setItem("local:filterSettings", filterAssignment)
+    }
+
+    saveFilterSettings()
+  }, [filterAssignment])
 
   const handleOpenModal = useCallback(() => {
     const currentUrl = window.location.href

--- a/entrypoints/content/components/AssignmentFilter.tsx
+++ b/entrypoints/content/components/AssignmentFilter.tsx
@@ -8,21 +8,37 @@ type Props = {
   obj: TAssignmentFilter
   setObj: React.Dispatch<React.SetStateAction<TAssignmentFilter>>
   inputLabel: string
-  itemKey: keyof TAssignmentFilter
+  itemKey:
+    | keyof TAssignmentFilter["type"]
+    | keyof TAssignmentFilter["submit"]
+    | keyof TAssignmentFilter["assessmentType"]
+  section: keyof TAssignmentFilter
 }
 
 const AssignmentFilter: React.FC<Props> = (props) => {
   return (
-    <DropdownItem htmlFor={props.itemKey}>
+    <DropdownItem>
       <input
-        id={props.itemKey}
-        type="checkbox"
-        defaultChecked={props.obj[props.itemKey]}
-        onChange={() => {
-          props.setObj({
+        type="radio"
+        name={props.section}
+        checked={
+          (props.obj[props.section] as { [key: string]: boolean })[
+            props.itemKey
+          ]
+        }
+        onChange={(event) => {
+          const updatedSection = Object.keys(props.obj[props.section]).reduce(
+            (acc, key) => ({
+              ...acc,
+              [key]: key === props.itemKey ? event.target.checked : false,
+            }),
+            {}
+          )
+          const updateObj = {
             ...props.obj,
-            [props.itemKey]: !props.obj[props.itemKey],
-          })
+            [props.section]: updatedSection,
+          }
+          props.setObj(updateObj)
         }}
       />
       {props.inputLabel}

--- a/entrypoints/content/components/AssignmentFilter.tsx
+++ b/entrypoints/content/components/AssignmentFilter.tsx
@@ -1,0 +1,33 @@
+import React from "React"
+
+import { TAssignmentFilter } from "@/types"
+
+import { DropdownItem } from "./styled/Dropdown"
+
+type Props = {
+  obj: TAssignmentFilter
+  setObj: React.Dispatch<React.SetStateAction<TAssignmentFilter>>
+  inputLabel: string
+  itemKey: keyof TAssignmentFilter
+}
+
+const AssignmentFilter: React.FC<Props> = (props) => {
+  return (
+    <DropdownItem htmlFor={props.itemKey}>
+      <input
+        id={props.itemKey}
+        type="checkbox"
+        defaultChecked={props.obj[props.itemKey]}
+        onChange={() => {
+          props.setObj({
+            ...props.obj,
+            [props.itemKey]: !props.obj[props.itemKey],
+          })
+        }}
+      />
+      {props.inputLabel}
+    </DropdownItem>
+  )
+}
+
+export default AssignmentFilter

--- a/entrypoints/content/components/styled/Dropdown.tsx
+++ b/entrypoints/content/components/styled/Dropdown.tsx
@@ -1,5 +1,10 @@
 import styled from "styled-components"
 
+export const ButtonContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`
+
 export const DropdownButton = styled.button`
   display: flex;
   align-items: center;
@@ -37,6 +42,7 @@ export const DropdownContent = styled.div`
 export const DropdownItem = styled.label`
   margin: 0;
   display: block;
+  align-items: inline;
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   border-bottom: 1px solid ${({ theme }) => theme.border};
@@ -54,7 +60,7 @@ export const DropdownLabel = styled.div`
   padding: 0.5rem 0.75rem;
   font-weight: 500;
   color: ${({ theme }) => theme.textMuted};
-  font-size: 0.875rem;
+  font-size: 1rem;
   background-color: ${({ theme }) => theme.cardBg};
   border-bottom: 1px solid ${({ theme }) => theme.border};
 `

--- a/entrypoints/content/components/styled/Dropdown.tsx
+++ b/entrypoints/content/components/styled/Dropdown.tsx
@@ -1,8 +1,17 @@
 import styled from "styled-components"
 
-export const ButtonContainer = styled.div`
+export const InlineContainer = styled.div`
   display: flex;
   gap: 10px;
+`
+
+export const LinkText = styled.p`
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover {
+    cursor: pointer;
+  }
 `
 
 export const DropdownButton = styled.button`

--- a/types/index.ts
+++ b/types/index.ts
@@ -6,33 +6,44 @@ export type AssignmentResponse = {
     firstname_th: string
     lastname_th: string
   }>
-  activities: Array<{
-    id: number
-    user_id: number
-    class_id: number
-    adv_starred: number
-    group_type: string
-    type: string
-    peer_assessment: number
-    is_allow_repeat: number
-    title: string
-    description: string
-    start_date: string
-    due_date: string | null
-    edit_group_mode: string
-    created_at: string
-    user: number
-    activity_submission_id: number | null
-    class_user_id: number
-    activity_group_id: number | null
-    activity_group_name: string | null
-    activity_submission_submitted_at: string | null
-    due_date_exceed: boolean
-    quiz_submission_is_submitted: number
-    count_group_member: number
-    activity_submission_is_late: boolean
-    fileactivities: any[]
-    questions: any[]
-    submissions: any[]
-  }>
+  activities: TActivity[]
+}
+
+export type TActivity = {
+  id: number
+  user_id: number
+  class_id: number
+  adv_starred: number
+  group_type: string
+  type: string
+  peer_assessment: number
+  is_allow_repeat: number
+  title: string
+  description: string
+  start_date: string
+  due_date: string | null
+  edit_group_mode: string
+  created_at: string
+  user: number
+  activity_submission_id: number | null
+  class_user_id: number
+  activity_group_id: number | null
+  activity_group_name: string | null
+  activity_submission_submitted_at: string | null
+  due_date_exceed: boolean
+  quiz_submission_is_submitted: number
+  count_group_member: number
+  activity_submission_is_late: boolean
+  fileactivities: any[]
+  questions: any[]
+  submissions: any[]
+}
+
+export type TAssignmentFilter = {
+  isSubmit: boolean
+  isNotSubmit: boolean
+  isIND: boolean
+  isGRP: boolean
+  isAssignment: boolean
+  isQuiz: boolean
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -40,10 +40,16 @@ export type TActivity = {
 }
 
 export type TAssignmentFilter = {
-  isSubmit: boolean
-  isNotSubmit: boolean
-  isIND: boolean
-  isGRP: boolean
-  isAssignment: boolean
-  isQuiz: boolean
+  submit: {
+    isSubmit: boolean
+    isNotSubmit: boolean
+  }
+  type: {
+    isIND: boolean
+    isGRP: boolean
+  }
+  assessmentType: {
+    isAssignment: boolean
+    isQuiz: boolean
+  }
 }


### PR DESCRIPTION
After my friends and I used this extension, we found it very helpful for keeping track of our tasks. However, since we have many tasks displayed in the modal, we asked to have a filter option to show only the tasks we need.

**This feature allows filtering assessments in classes based on specific criteria, such as viewing only unsubmitted tasks or only group tasks.**


![Screenshot 2568-01-29 at 22 38 37](https://github.com/user-attachments/assets/b9151b47-8fc4-46b1-bb50-cf78bb5030be)
